### PR TITLE
Github banner linked fixed

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -157,7 +157,7 @@ padding: 0px;
         <li><a href="/month">Month</a></li>
         <li><a href="/year">Year</a></li>
       </ul>
-      <a href="https://github.com/inconditus/hackit"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
+      <a href="https://github.com/plasx/hackit"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
     </div>
     <div class="container">
 


### PR DESCRIPTION
The previous banner linked to https://github.com/Inconditus/hackit which no longer exists. Updated to https://github.com/plasx/hackit